### PR TITLE
Add links to tests

### DIFF
--- a/test/fixtures/links.txt
+++ b/test/fixtures/links.txt
@@ -214,3 +214,15 @@ example.com/䨹
 президент.рф
 
 xn--d1abbgf6aiiy.xn--p1ai
+
+http://www.bürgerentscheid-krankenhäuser.de
+
+http://www.xn--brgerentscheid-krankenhuser-xkc78d.de
+
+http://bündnis-für-krankenhäuser.de/wp-content/uploads/2011/11/cropped-logohp.jpg
+
+http://xn--bndnis-fr-krankenhuser-i5b27cha.de/wp-content/uploads/2011/11/cropped-logohp.jpg
+
+http://ﻡﻮﻘﻋ.ﻭﺯﺍﺭﺓ-ﺍﻼﺘﺻﺍﻼﺗ.ﻢﺻﺭ/
+
+http://xn--4gbrim.xn----ymcbaaajlc6dj7bxne2c.xn--wgbh1c/


### PR DESCRIPTION
This PR adds some tests we already had in our jasmine tests for diaspora*. Users had problems with those URLs before. (before we used markdown-it) I guess a few more tests won't hurt and could prevent regressions.