### PR TITLE
Add schema on a fuzzy link match

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ linkify
 console.log(linkify.test('Site github.com!'));  // true
 
 console.log(linkify.match('Site github.com!')); // [ {
-                                                //   schema: "",
+                                                //   schema: "http:",
                                                 //   index: 5,
                                                 //   lastIndex: 15,
                                                 //   raw: "github.com",

--- a/index.js
+++ b/index.js
@@ -463,7 +463,7 @@ LinkifyIt.prototype.test = function test(text) {
           shift = ml.index + ml[1].length;
 
           if (this.__index__ < 0 || shift < this.__index__) {
-            this.__schema__     = '';
+            this.__schema__     = 'http:';
             this.__index__      = shift;
             this.__last_index__ = ml.index + ml[0].length;
           }

--- a/test/test.js
+++ b/test/test.js
@@ -237,6 +237,7 @@ describe('API', function () {
 
     assert.equal(l.test('google.com.'), true);
     assert.equal(l.match('google.com.')[0].text, 'google.com');
+    assert.equal(l.match('google.com.')[0].schema, 'http:');
   });
 
 
@@ -249,6 +250,7 @@ describe('API', function () {
 
     assert.equal(l.test('foo@bar.com.'), true);
     assert.equal(l.match('foo@bar.com.')[0].text, 'foo@bar.com');
+    assert.equal(l.match('foo@bar.com.')[0].schema, 'mailto:');
   });
 
 


### PR DESCRIPTION
Hi,

When a fuzzy email is matched, the schema is set on the match but not on a fuzzy link. Do you know why? I think the schema should always be set on a match.

Best,
David