### PR TITLE
Bump uc.micro dependy to 1.0.5 making it full MIT compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "uc.micro": "^1.0.1"
+    "uc.micro": "^1.0.5"
   },
   "devDependencies": {
     "ansi": "^0.3.0",


### PR DESCRIPTION
Just bumping this to make it full MIT compatible after the License clarification in `uc.micro` as in `markdown-it`.