### PR TITLE
typings: init at 2.0.3

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,33 @@
+type Validate = (text: string, pos: number, self: LinkifyIt) => number | boolean;
+type Normalize = (match: Match) => void;
+
+interface Rule {
+  validate: Validate | RegExp;
+  normalize?: Normalize;
+}
+
+interface Options {
+  fuzzyLink?: boolean;
+  fuzzyIP?: boolean;
+  fuzzyEmail?: boolean;
+}
+
+interface Match {
+  index: number;
+  lastIndex: number;
+  raw: string;
+  schema: string;
+  text: string;
+  url: string;
+}
+
+export default class LinkifyIt {
+  public add(schema: string, rule: Rule): LinkifyIt;
+  public match(text: string): Match[];
+  public normalize(raw: string): string;
+  public pretest(text: string): boolean;
+  public set(options: Options): LinkifyIt;
+  public test(text: string): boolean;
+  public testSchemaAt(text: string, schemaName: string, pos: number): number;
+  public tlds(list: string | string[], keepOld?: boolean): LinkifyIt;
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "index.js",
     "lib/"
   ],
+  "main": "index.js",
+  "types": "index.d.ts",
   "license": "MIT",
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
**what**
add typings for better typescript support

**why**
the typings in the definitely typed repository are not representing the current implementation. in fact it would be keep the typings in sync by having them closer to the source code