### PR TITLE
Allowing more than 4 dots 

### DIFF
--- a/lib/re.js
+++ b/lib/re.js
@@ -56,7 +56,8 @@ module.exports = function (opts) {
           '\\"(?:(?!' + re.src_ZCc + '|["]).)+\\"|' +
           "\\'(?:(?!" + re.src_ZCc + "|[']).)+\\'|" +
           "\\'(?=" + re.src_pseudo_letter + '|[-]).|' +  // allow `I'm_king` if no pair found
-          '\\.{2,}[a-zA-Z0-9%/]|' + // github has ... in commit range links,
+          '\\.{2,}[a-zA-Z0-9%/]|' +  // google has many dots in "google search" links.
+                                     // github has ... in commit range links,
                                      // google has .... in links (issue #66)
                                      // Restrict to
                                      // - english

--- a/lib/re.js
+++ b/lib/re.js
@@ -56,7 +56,7 @@ module.exports = function (opts) {
           '\\"(?:(?!' + re.src_ZCc + '|["]).)+\\"|' +
           "\\'(?:(?!" + re.src_ZCc + "|[']).)+\\'|" +
           "\\'(?=" + re.src_pseudo_letter + '|[-]).|' +  // allow `I'm_king` if no pair found
-          '\\.{2,4}[a-zA-Z0-9%/]|' + // github has ... in commit range links,
+          '\\.{2,}[a-zA-Z0-9%/]|' + // github has ... in commit range links,
                                      // google has .... in links (issue #66)
                                      // Restrict to
                                      // - english

--- a/test/fixtures/links.txt
+++ b/test/fixtures/links.txt
@@ -166,6 +166,8 @@ https://github.com/markdown-it/linkify-it/compare/360b13a733f521a8d4903d3a5e1e46
 
 https://www.google.com/search?source=hp&ei=y0QtW7yUGpiq0PEPv5qv8Ag&q=best+sci+fi+books&oq=best+sci&gs_l=psy-ab.3.1.0j0i20i264k1j0j0i131k1j0l6.2035.4079.0.5985.9.8.0.0.0.0.132.797.5j3.8.0....0...1c.1.64.psy-ab..1.8.797.0..35i39k1j0i67k1.0.iug3EHWIyxc
 
+https://www.google.com/search?sxsrf=ACYBGNTJFmX-GjNJ8fM-2LCkqyNyxGU1Ng%3A1575534146332&ei=Qr7oXf7rE4rRrgSEgrmoAw&q=clover&oq=clover&gs_l=psy-ab.3..0i67j0l9.2986.3947..4187...0.2..0.281.1366.1j0j5......0....1..gws-wiz.......0i71j35i39j0i131.qWp1nz4IJVA&ved=0ahUKEwj-lP6Iip7mAhWKqIsKHQRBDjUQ4dUDCAs&uact=5
+
 http://example.com/foo_bar...
 http://example.com/foo_bar
 


### PR DESCRIPTION
Why don't you allow more than 4 dots?
for example
 https://www.google.com/search?sxsrf=ACYBGNTJFmX-GjNJ8fM-2LCkqyNyxGU1Ng%3A1575534146332&ei=Qr7oXf7rE4rRrgSEgrmoAw&q=clover&oq=clover&gs_l=psy-ab.3..0i67j0l9.2986.3947..4187...0.2..0.281.1366.1j0j5......0....1..gws-wiz.......0i71j35i39j0i131.qWp1nz4IJVA&ved=0ahUKEwj-lP6Iip7mAhWKqIsKHQRBDjUQ4dUDCAs&uact=5
It's just google links and there are more than 4 dots, is it wrong link for you?

with help just a little change I've given the opportunity to recognize such links

Please merge it, or explain to me why it works in such a way