### PR TITLE
Allow underscores in domain part

### DIFF
--- a/lib/re.js
+++ b/lib/re.js
@@ -23,7 +23,7 @@ module.exports = function (opts) {
   // All possible word characters (everything without punctuation, spaces & controls)
   // Defined via punctuation & spaces to save space
   // Should be something like \p{\L\N\S\M} (\w but without `_`)
-  re.src_pseudo_letter       = '(?:(?!' + text_separators + '|' + re.src_ZPCc + ')' + re.src_Any + ')';
+  re.src_pseudo_letter = '(?:(?!' + text_separators + '|' + re.src_ZPCc + ')' + re.src_Any + '|[a-z0-9]+_[a-z0-9]+)';
   // The same as abothe but without [0-9]
   // var src_pseudo_letter_non_d = '(?:(?![0-9]|' + src_ZPCc + ')' + src_Any + ')';
 

--- a/test/fixtures/links.txt
+++ b/test/fixtures/links.txt
@@ -9,6 +9,8 @@ http://example.com/
 
 http://example.com/foo_bar/
 
+http://example_test.com/foo_bar/
+
 http://user:pass@example.com:8080
 
 http://user@example.com

--- a/test/fixtures/links.txt
+++ b/test/fixtures/links.txt
@@ -11,6 +11,8 @@ http://example.com/foo_bar/
 
 http://example_test.com/foo_bar/
 
+http://example_test_again.com/foo_bar/
+
 http://user:pass@example.com:8080
 
 http://user@example.com

--- a/test/fixtures/not_links.txt
+++ b/test/fixtures/not_links.txt
@@ -17,6 +17,8 @@ localhost/
 
 _http://example.com
 http://_example.com
+http://example_.com
+http://example_test_.com
 _//example.com
 _example.com
 http://example.com_

--- a/test/fixtures/not_links.txt
+++ b/test/fixtures/not_links.txt
@@ -16,6 +16,7 @@ localhost/
 //test              % Don't allow single level protocol-less domains to avoid false positives
 
 _http://example.com
+http://_example.com
 _//example.com
 _example.com
 http://example.com_


### PR DESCRIPTION
Fixes https://github.com/markdown-it/linkify-it/issues/67
Fixes https://github.com/markdown-it/linkify-it/issues/68

As far as I can tell, this fixes the issue but the code style is probably not really up to what's already in the codebase so please let me know how I can improve that 😁 