### PR TITLE
Bugfix for: Links with "_" in the domain name are not regarded as links

### DIFF
--- a/lib/re.js
+++ b/lib/re.js
@@ -106,7 +106,7 @@ module.exports = function (opts) {
       '|' +
       '(?:' + re.src_pseudo_letter + ')' +
       '|' +
-      '(?:' + re.src_pseudo_letter + '(?:-|' + re.src_pseudo_letter + '){0,61}' + re.src_pseudo_letter + ')' +
+      '(?:' + re.src_pseudo_letter + '(?:-|_|' + re.src_pseudo_letter + '){0,61}' + re.src_pseudo_letter + ')' +
     ')';
 
   re.src_host =

--- a/test/fixtures/links.txt
+++ b/test/fixtures/links.txt
@@ -55,6 +55,12 @@ http://example.com
 http://lyricstranslate.com/en/someone-you-നിന്നെ-പോലൊരാള്‍.html % With control character
 http://lyricstranslate.com/en/someone-you-നിന്നെ-പോലൊരാള്‍.html
 
+https://api_stage.dzcode.io
+https://api_stage.dzcode.io
+
+https://api_stage.dz_code.io
+https://api_stage.dz_code.io
+
 %
 % localhost (only with protocol allowed)
 %
@@ -114,6 +120,11 @@ GOOGLE.COM
 google.xxx // known tld
 google.xxx
 
+api_stage.dzcode.io
+api_stage.dzcode.io
+
+api_stage.dz_code.io
+api_stage.dz_code.io
 
 %
 % Correct termination for . , ! ? [] {} () "" ''


### PR DESCRIPTION
This PR fixed the bug reported in #95 

The change is adding a `_` in `src_pseudo_letter` regEx, to be able to detect links such as:

- api_stage.dzcode.io
- api_stage.dz_code.io

which are valid links, see:
https://stackoverflow.com/a/2183140/8113942

# type of change:

- [x] non-breaking changes