### PR TITLE
Fix paths containing unencoded ` followed by punctuation

### DIFF
--- a/lib/re.js
+++ b/lib/re.js
@@ -57,7 +57,7 @@ module.exports = function (opts) {
           '\\{(?:(?!' + re.src_ZCc + '|[}]).)*\\}|' +
           '\\"(?:(?!' + re.src_ZCc + '|["]).)+\\"|' +
           "\\'(?:(?!" + re.src_ZCc + "|[']).)+\\'|" +
-          "\\'(?=" + re.src_pseudo_letter + '|[-])|' +  // allow `I'm_king` if no pair found
+          "\\'(?=" + re.src_pseudo_letter + '|[-|' + re.src_ZPCc + '])|' +  // allow `I'm_king` if no pair found
           '\\.{2,}[a-zA-Z0-9%/&]|' + // google has many dots in "google search" links (#66, #81).
                                      // github has ... in commit range links,
                                      // Restrict to

--- a/test/fixtures/links.txt
+++ b/test/fixtures/links.txt
@@ -135,6 +135,10 @@ http://foo.com/blah_blah_"doublequoted"
 
 http://foo.com/blah_blah_'singlequoted'
 
+https://domain.com/@username:4/some-words'&=0
+
+https://domain.com/@username:4/some-words':0
+
 (Scoped like http://example.com/foo_bar)
 http://example.com/foo_bar
 


### PR DESCRIPTION
linkify-it currently supports apostrophes in the path, such as:

http://foo.com/blah_blah_I'm_king

However, there is no support for apostrophes followed by punctuation. This link is not found by linkify-it:

https://odysee.com/@EatMoreVegans:4/can-chefstemp-knock-thermoworks':0

What's happening here is that Odysee generates links using the first part of video titles. The title of the video linked above is "Can ChefsTemp Knock ThermoWorks' Thermapen One Off the Throne?". Their logic happens to end the path with the `'` in the video title followed by punctuation. 

Services that includes unencoded apostrophes in paths could follow that apostrophe with a number of different characters. Here's a Google Cache link that follows an unencoded `'` with a `(`.

http://webcache.googleusercontent.com/search?q=cache:jkWRWOTPZXwJ:app.searchenabler.com/experiments/unsafe/%2520!%24%26'()*%2B,-.:%3B%253C%3D%253E%40%5B%255C%5D%255E_%2560%257B%257C%257D~+&cd=1&hl=en&ct=clnk

All three of these links are supported by my changes.