### PR TITLE
fix: recognize IPv4 address literals in email hosts

### DIFF
--- a/src/rebuilder.ts
+++ b/src/rebuilder.ts
@@ -110,6 +110,12 @@ export class REBuilder {
     )
   }
 
+  get_ipv4_mail_host () {
+    return this.cache.src_ipv4_mail_host ??= new RegExp(
+      `\\[${this.get_ipv4_addr().source}\\]`
+    )
+  }
+
   get_auth () {
     return this.cache.src_auth ??= new RegExp(
       // Prohibit any of "@/[]()" in user/pass to avoid wrong domain fetch.
@@ -284,6 +290,8 @@ export class REBuilder {
       '(?:' +
         this.get_ipv6_mail_host().source +
         '|' +
+        this.get_ipv4_mail_host().source +
+        '|' +
         `(?:(?:(?:${this.get_domain().source})\\.){0,4}${this.get_domain().source})` +
       ')' +
       this.get_host_terminator().source
@@ -295,6 +303,8 @@ export class REBuilder {
     return this.cache.src_fuzzy_mail_host ??= new RegExp(
       '(?:' +
         this.get_ipv6_mail_host().source +
+        '|' +
+        this.get_ipv4_mail_host().source +
         '|' +
         `(?:(?:(?:${this.get_domain().source})[.]){1,4}${this.get_domain_root().source})` +
       ')' +

--- a/test/fixtures/links.txt
+++ b/test/fixtures/links.txt
@@ -288,6 +288,8 @@ mailto:user@[IPv6:::1]
 
 mailto:user@[IPv6:2001:db8::1]
 
+mailto:user@[192.168.1.1]
+
 (foobar email@example.com)
 email@example.com
 


### PR DESCRIPTION
`linkify-it` already recognizes the IPv6 address-literal email host form (`user@[IPv6:::1]`, added in 6.0.0), but not the IPv4 counterpart. Per RFC 5321 §4.1.3 an `address-literal` may be `[IPv4-address-literal]` with no tag, so `user@[192.168.1.1]` is a valid mailbox host.

Currently `mailto:user@[192.168.1.1]` is not linkified, and with `fuzzyIP` enabled it is worse: the scheme and local part are dropped and a bare `192.168.1.1` IP link is returned instead. This adds the missing `get_ipv4_mail_host()` sibling and wires it into `get_mail_host()`/`get_fuzzy_mail_host()`, mirroring the existing IPv6 handling.
